### PR TITLE
Allow turbulence api to advertise a host url

### DIFF
--- a/jobs/turbulence_agent/templates/config.json.erb
+++ b/jobs/turbulence_agent/templates/config.json.erb
@@ -6,7 +6,7 @@ JSON.dump(
 	"AgentID" => "_agent_id_",
 
 	"API" => {
-		"Host" => api.instances.first.address,
+		"Host" => api.p("advertised_host").empty? ? api.instances.first.address : api.p("advertised_host"),
 		"Port" => api.p("listen_port"),
 		"CACert" => api.p("cert.ca"),
 		"Username" => api.p("username"),

--- a/jobs/turbulence_api/spec
+++ b/jobs/turbulence_api/spec
@@ -15,6 +15,7 @@ provides:
   type: turbulence_api
   properties:
   - listen_port
+  - advertised_host
   - cert
   - username
   - password
@@ -26,6 +27,10 @@ properties:
   listen_port:
     description: "Port to listen on"
     default: 8080
+
+  advertised_host:
+    description: "Advertised hostname of the API server"
+    default: ""
 
   username:
     description: "Username for the API authentication"


### PR DESCRIPTION
We want to create our turbulence api certificate with a domain name, so we don't have to use a static ip for our turbulence api job. To do that we need the `turbulence_agent` to communicate using that domain name.

Let us know if this looks okay to pull in.

Thanks,
Christian