### PR TITLE
fix concurrency issue

### DIFF
--- a/src/github.com/cppforlife/turbulence/scheduledinc/scheduler.go
+++ b/src/github.com/cppforlife/turbulence/scheduledinc/scheduler.go
@@ -70,7 +70,8 @@ func (s *Scheduler) performCronReset() {
 
 	s.itemsLock.Lock()
 
-	for _, si := range s.items {
+	for i, _ := range s.items {
+		si := s.items[i]
 		s.cron.AddFunc(si.Schedule, func() {
 			err := si.Execute()
 			if err != nil {


### PR DESCRIPTION
there is an issue in the scheduler where the function definition will always take the last entry of the item list